### PR TITLE
Pinned Jinja2 to version 3.0.3

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,6 +6,7 @@ sphinx-markdown-tables==0.0.15
 sphinxext.adaptive-youtube==0.0.2
 # sphinx-rtd-theme==0.5.0
 # sphinxjp.themes.basicstrap==0.5.0
+Jinja2==3.0.3
 
 # dependencies for utils
 beautifulsoup4==4.9.3


### PR DESCRIPTION
There is a dependency problem, the latest `Jinja2 3.1.x` will break our current `Sphinx==3.4.0`

![image](https://user-images.githubusercontent.com/73963722/187111630-c877ea54-f9c4-404a-8653-d0aaca5b6033.png)

In order to fix this problem,and not break our code, I pinned the Jinja2 package to exactly verison: `3.0.3`

Ref: https://github.com/pallets/jinja/issues/1630